### PR TITLE
修复在单元测试过程退出应用，单元测试将等待单元测试执行结果不会退出

### DIFF
--- a/src/dotnetCampus.UITest.WPF/UITestMethodProxy.cs
+++ b/src/dotnetCampus.UITest.WPF/UITestMethodProxy.cs
@@ -22,7 +22,12 @@ namespace dotnetCampus.UITest.WPF
             {
                 var task = Application.Current.Dispatcher.Invoke(async () =>
                 {
-                    return await contractTestCase.ExecuteAsync();
+                    var result = await contractTestCase.ExecuteAsync()
+                        // 如果在执行过程，应用退出了，那在没有加上 ConfigureAwait 设置为 false 那将需要调度回 UI 线程，才能返回
+                        // 由于应用退出了，也就是 UI 线程不会调度的任务
+                        // 因此不会返回，单元测试将会卡住
+                        .ConfigureAwait(false);
+                    return result;
                 });
 
                 return task.Result;

--- a/tests/MSTest.Extensions.Tests/Contracts/ContractTestCaseAttributeTests.cs
+++ b/tests/MSTest.Extensions.Tests/Contracts/ContractTestCaseAttributeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MSTest.Extensions.Contracts;
 
@@ -34,6 +35,7 @@ namespace MSTest.Extensions.Tests.Contracts
         }
 
         [ContractTestCase]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void WithArguments_WithFormatString()
         {
             "If {0}, then {1}.".Test((string condition, string result) =>
@@ -43,6 +45,7 @@ namespace MSTest.Extensions.Tests.Contracts
         }
 
         [ContractTestCase]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void WithArguments_WithPartialFormatString()
         {
             "If {0}, then something...".Test((string condition, string result) =>
@@ -52,6 +55,7 @@ namespace MSTest.Extensions.Tests.Contracts
         }
 
         [ContractTestCase]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void WithArguments_WithoutFormatString()
         {
             "If something..., then something others...".Test((string condition, string result) =>


### PR DESCRIPTION
单元测试的执行结果在等待 UI 线程调度，但是 UI 线程已经退出，不会再调度